### PR TITLE
Move log4j dependency to junixsocket-demo

### DIFF
--- a/junixsocket-demo/pom.xml
+++ b/junixsocket-demo/pom.xml
@@ -52,5 +52,10 @@
       <version>1.7.7</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>log4j</groupId>
+      <artifactId>log4j</artifactId>
+      <version>1.2.17</version>
+    </dependency>
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -84,11 +84,6 @@ In contrast to other implementations, junixsocket extends the Java Sockets API (
       <version>4.11</version>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
-      <version>1.2.17</version>
-    </dependency>
   </dependencies>
 
   <reporting>


### PR DESCRIPTION
Libraries in general should not depend on log4j as library users
should be able to choose logging library. log4j is used only by the
demo module so move the dependency there.