### PR TITLE
Numerous cleanups, mostly to native code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ dependency-reduced-pom.xml
 pom.xml.releaseBackup
 /release.properties
 /eclipse
+/bin/
+\?/
+.m2/

--- a/junixsocket-common/src/main/java/org/newsclub/net/unix/AFUNIXSocket.java
+++ b/junixsocket-common/src/main/java/org/newsclub/net/unix/AFUNIXSocket.java
@@ -32,11 +32,7 @@ public class AFUNIXSocket extends Socket {
 
   private AFUNIXSocket(final AFUNIXSocketImpl impl) throws IOException {
     super(impl);
-    try {
-      NativeUnixSocket.setCreated(this);
-    } catch (UnsatisfiedLinkError e) {
-      e.printStackTrace();
-    }
+    NativeUnixSocket.setCreated(this);
   }
 
   /**

--- a/junixsocket-common/src/main/java/org/newsclub/net/unix/AFUNIXSocketAddress.java
+++ b/junixsocket-common/src/main/java/org/newsclub/net/unix/AFUNIXSocketAddress.java
@@ -54,7 +54,7 @@ public class AFUNIXSocketAddress extends InetSocketAddress {
   public AFUNIXSocketAddress(final File socketFile, int port) throws IOException {
     super(0);
     if (port != 0) {
-      NativeUnixSocket.setPort1(this, port);
+      NativeUnixSocket.setPort(this, port);
     }
     this.socketFile = socketFile.getCanonicalPath();
   }

--- a/junixsocket-common/src/main/java/org/newsclub/net/unix/NativeUnixSocket.java
+++ b/junixsocket-common/src/main/java/org/newsclub/net/unix/NativeUnixSocket.java
@@ -52,15 +52,12 @@ final class NativeUnixSocket {
     Field field = null;
     try {
       field = klass.getDeclaredField(name);
-    } catch (Exception e) {
-      e.printStackTrace();
-    }
-    if (field == null) {
-      throw new RuntimeException("Cannot find field \"" + name + "\" in "
-          + klass.getName() + "\". Unsupported JVM?");
+    } catch (NoSuchFieldException e) {
+      throw new NoSuchFieldError("Cannot find field \"" + name + "\" in "
+          + klass.getName() + "\". Unsupported JVM?", e);
     }
     field.setAccessible(true);
-	  return field;
+    return field;
   }
 
   static {
@@ -68,14 +65,9 @@ final class NativeUnixSocket {
       Class.forName("org.newsclub.net.unix.NarSystem").getMethod("loadLibrary").invoke(null);
       registerNatives();
     } catch (ClassNotFoundException e) {
-      e.printStackTrace();
-      throw new IllegalStateException(
+      throw new NoClassDefFoundError(
           "Could not find NarSystem class.\n\n*** ECLIPSE USERS ***\nIf you're running from "
               + "within Eclipse, please try closing the \"junixsocket-native-common\" "
-              + "project\n", e);
-    } catch (Exception e) {
-      e.printStackTrace();
-      throw new IllegalStateException(e);
     }
     loaded = true;
   }

--- a/junixsocket-native/src/main/c/org_newsclub_net_unix_NativeUnixSocket.h
+++ b/junixsocket-native/src/main/c/org_newsclub_net_unix_NativeUnixSocket.h
@@ -103,62 +103,6 @@ JNIEXPORT void JNICALL Java_org_newsclub_net_unix_NativeUnixSocket_unlink
 JNIEXPORT jint JNICALL Java_org_newsclub_net_unix_NativeUnixSocket_available
   (JNIEnv *, jclass, jobject);
 
-/*
- * Class:     org_newsclub_net_unix_NativeUnixSocket
- * Method:    initServerImpl
- * Signature: (Lorg/newsclub/net/unix/AFUNIXServerSocket;Lorg/newsclub/net/unix/AFUNIXSocketImpl;)V
- */
-JNIEXPORT void JNICALL Java_org_newsclub_net_unix_NativeUnixSocket_initServerImpl
-  (JNIEnv *, jclass, jobject, jobject);
-
-/*
- * Class:     org_newsclub_net_unix_NativeUnixSocket
- * Method:    setCreated
- * Signature: (Lorg/newsclub/net/unix/AFUNIXSocket;)V
- */
-JNIEXPORT void JNICALL Java_org_newsclub_net_unix_NativeUnixSocket_setCreated
-  (JNIEnv *, jclass, jobject);
-
-/*
- * Class:     org_newsclub_net_unix_NativeUnixSocket
- * Method:    setConnected
- * Signature: (Lorg/newsclub/net/unix/AFUNIXSocket;)V
- */
-JNIEXPORT void JNICALL Java_org_newsclub_net_unix_NativeUnixSocket_setConnected
-  (JNIEnv *, jclass, jobject);
-
-/*
- * Class:     org_newsclub_net_unix_NativeUnixSocket
- * Method:    setBound
- * Signature: (Lorg/newsclub/net/unix/AFUNIXSocket;)V
- */
-JNIEXPORT void JNICALL Java_org_newsclub_net_unix_NativeUnixSocket_setBound
-  (JNIEnv *, jclass, jobject);
-
-/*
- * Class:     org_newsclub_net_unix_NativeUnixSocket
- * Method:    setCreatedServer
- * Signature: (Lorg/newsclub/net/unix/AFUNIXServerSocket;)V
- */
-JNIEXPORT void JNICALL Java_org_newsclub_net_unix_NativeUnixSocket_setCreatedServer
-  (JNIEnv *, jclass, jobject);
-
-/*
- * Class:     org_newsclub_net_unix_NativeUnixSocket
- * Method:    setBoundServer
- * Signature: (Lorg/newsclub/net/unix/AFUNIXServerSocket;)V
- */
-JNIEXPORT void JNICALL Java_org_newsclub_net_unix_NativeUnixSocket_setBoundServer
-  (JNIEnv *, jclass, jobject);
-
-/*
- * Class:     org_newsclub_net_unix_NativeUnixSocket
- * Method:    setPort
- * Signature: (Lorg/newsclub/net/unix/AFUNIXSocketAddress;I)V
- */
-JNIEXPORT void JNICALL Java_org_newsclub_net_unix_NativeUnixSocket_setPort
-  (JNIEnv *, jclass, jobject, jint);
-
 #ifdef __cplusplus
 }
 #endif

--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,8 @@ In contrast to other implementations, junixsocket extends the Java Sockets API (
     <module>junixsocket-common</module>
     <module>junixsocket-rmi</module>
     <module>junixsocket-mysql</module>
+    <module>junixsocket-native</module>
+    <module>junixsocket-native-common</module>
     <module>junixsocket-demo</module>
   </modules>
 


### PR DESCRIPTION
- use reflection instead of JNI for field and method access
- cache JNI field and method IDs and Java class references
- use thread-safe `strerror_r`, instead of the thread-unsafe `strerror`
