### PR TITLE
Using Get/SetByteArrayRegion instead of Get/SetByteArrayElements/ReleaseByteArrayElements.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ dependency-reduced-pom.xml
 pom.xml.releaseBackup
 /release.properties
 /eclipse
+.idea
+*.iml

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # junixsocket
 
+This project is a fork of [Christian Kohlschütter's junixsocket](https://github.com/fiken/junixsocket). The original project seems to be dead, and we've been unable to get in touch with him. This fork is compatible with pgjdbc (PostgreSQL) and contains some performance improvements.
+
 junixsocket is a Java/JNI library that allows the use of [Unix Domain Sockets](https://en.wikipedia.org/wiki/Unix_domain_socket) (AF_UNIX sockets) from Java.
 
 ## Why it's cool
@@ -9,45 +11,37 @@ junixsocket is a Java/JNI library that allows the use of [Unix Domain Sockets](h
 * Can connect to local MySQL server via Unix domain sockets (provides a *AFUNIXDatabaseSocketFactory* for Connector/J).
 * Apache 2.0 licensed.
 
+## Quick start
+Add the following dependencies to your project:
+```xml
+<dependency>
+  <groupId>no.fiken.oss.junixsocket</groupId>
+  <artifactId>junixsocket-common</artifactId>
+  <version>1.0.0</version>
+</dependency>
+<dependency>
+  <groupId>no.fiken.oss.junixsocket</groupId>
+  <artifactId>junixsocket-native-common</artifactId>
+  <version>1.0.0</version>
+</dependency>
+```
+Connect to a socket:
+```java
+AFUNIXSocket s = AFUNIXSocket.newInstance();
+s.connect(new AFUNIXSocketAddress(new File(path)));
+//Use like an ordinary socket
+```
+
 ## Licensing
 
-junixsocket has been written by Christian Kohlschütter. It is released under the Apache 2.0 License.
-
-Commercial support is available through [http://www.kohlschutter.com/ Kohlschütter Search Intelligence].
-
-## Changelog
+It is released under the Apache 2.0 License.
 
 ### Noteworthy changes
 
-  * _(2014-09-29)_ *junixsocket 2.0.1*
-
-   * **Bugfix:** Added byte array bounds checking to read/write methods.
-   * Fix C compiler warnings
-   * Remove synchronized byte[] array for single-byte reads/writes.
-
-  * _(2014-09-28)_ *junixsocket 2.0.0*
-   * Moved from *Google Code* to *GitHub*.
-   * Now uses Maven as the build system, code is distributed to the *Maven Central* repository.
-   * C code is built using *nar-maven-plugin*
-   * JNI libraries are loaded using *native-lib-loader*
+  * _(2016-08-18)_ *junixsocket 1.0.0*
+    * Increased performance when reading data to large byte-array (prevent array-copy)
+    * Added workaround so it's possible to use this library with pgjdbc (PostgreSQL)
+    * Temporarily removed Mac and 32bit-support (we'll hopefully fix this in a later release)
 
 See the commit log for details.
 
-For 1.x releases, please see [https://code.google.com/p/junixsocket](https://code.google.com/p/junixsocket).
-
-## Documentation
-
-For now, please refer to the [Wiki on Google Code](http://code.google.com/p/junixsocket/w/list). 
-
-Quick links:
- * [Getting Started](http://code.google.com/p/junixsocket/wiki/GettingStarted)
- * [Socket Demo](http://code.google.com/p/junixsocket/source/browse/#svn/trunk/junixsocket/src/demo/org/newsclub/net/unix/demo)
- * [RMI Demo](http://code.google.com/p/junixsocket/source/browse/#svn/trunk/junixsocket/src/demo/org/newsclub/net/unix/demo/rmi)
- * [MySQL Socket Demo](http://code.google.com/p/junixsocket/wiki/ConnectingToMySQL)
- * [API Javadocs](http://junixsocket.googlecode.com/svn/trunk/junixsocket/javadoc/index.html)
-
-## Related Work
-
- * [JUDS](http://code.google.com/p/juds/) (LGPL, no RMI, not using Java Sockets API)
- * J-BUDS (LGPL, no RMI, not using Java Sockets API, orphaned)
- * gnu.net.local (GPL with Classpath exception, no RMI, not using Java Sockets API, orphaned) -- [Archive mirror](http://web.archive.org/web/20060702213439/http://www.nfrese.net/software/gnu_net_local/overview.html).

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ It is released under the Apache 2.0 License.
   * _(2016-08-18)_ *junixsocket 1.0.0*
     * Increased performance when reading data to large byte-array (prevent array-copy)
     * Added workaround so it's possible to use this library with pgjdbc (PostgreSQL)
-    * Temporarily removed Mac and 32bit-support (we'll hopefully fix this in a later release)
+    * Temporarily removed Mac  (we'll hopefully fix this in a later release)
 
 See the commit log for details.
 

--- a/junixsocket-common/pom.xml
+++ b/junixsocket-common/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>no.fiken.oss.junixsocket</groupId>
     <artifactId>junixsocket-parent</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.0.1-SNAPSHOT</version>
   </parent>
   <name>junixsocket-common</name>
   <properties>

--- a/junixsocket-common/pom.xml
+++ b/junixsocket-common/pom.xml
@@ -4,10 +4,9 @@
   <artifactId>junixsocket-common</artifactId>
   <packaging>jar</packaging>
   <parent>
-    <groupId>com.kohlschutter.junixsocket</groupId>
+    <groupId>no.fiken.oss.junixsocket</groupId>
     <artifactId>junixsocket-parent</artifactId>
-    <version>2.0.5-SNAPSHOT</version>
-    <relativePath>../pom.xml</relativePath>
+    <version>1.0.0-SNAPSHOT</version>
   </parent>
   <name>junixsocket-common</name>
   <properties>

--- a/junixsocket-common/src/main/java/org/newsclub/net/unix/AFUNIXSocket.java
+++ b/junixsocket-common/src/main/java/org/newsclub/net/unix/AFUNIXSocket.java
@@ -101,6 +101,11 @@ public class AFUNIXSocket extends Socket {
   @Override
   public void connect(SocketAddress endpoint, int timeout) throws IOException {
     if (!(endpoint instanceof AFUNIXSocketAddress)) {
+      // This is a hack to get this to work with the postgresql jdbc driver.
+      if (isConnected()) {
+        return;
+      }
+
       throw new IOException("Can only connect to endpoints of type "
           + AFUNIXSocketAddress.class.getName());
     }

--- a/junixsocket-common/src/main/java/org/newsclub/net/unix/AFUNIXSocketImpl.java
+++ b/junixsocket-common/src/main/java/org/newsclub/net/unix/AFUNIXSocketImpl.java
@@ -92,12 +92,6 @@ class AFUNIXSocketImpl extends SocketImpl {
     throw new SocketException("Cannot bind to this type of address: " + InetAddress.class);
   }
 
-  private void checkClose() throws IOException {
-    if (closedInputStream && closedOutputStream) {
-      // close();
-    }
-  }
-
   @Override
   protected synchronized void close() throws IOException {
     if (closed) {
@@ -188,8 +182,8 @@ class AFUNIXSocketImpl extends SocketImpl {
       try {
         return NativeUnixSocket.read(fd, buf, off, len);
       } catch (final IOException e) {
-        throw (IOException) new IOException(e.getMessage() + " at "
-            + AFUNIXSocketImpl.this.toString()).initCause(e);
+        throw new IOException(e.getMessage() + " at "
+            + AFUNIXSocketImpl.this.toString(), e);
       }
     }
 
@@ -215,13 +209,11 @@ class AFUNIXSocketImpl extends SocketImpl {
       }
 
       closedInputStream = true;
-      checkClose();
     }
 
     @Override
     public int available() throws IOException {
-      final int av = NativeUnixSocket.available(fd);
-      return av;
+      return NativeUnixSocket.available(fd);
     }
   }
 
@@ -252,8 +244,8 @@ class AFUNIXSocketImpl extends SocketImpl {
           off += written;
         }
       } catch (final IOException e) {
-        throw (IOException) new IOException(e.getMessage() + " at "
-            + AFUNIXSocketImpl.this.toString()).initCause(e);
+        throw new IOException(e.getMessage() + " at "
+            + AFUNIXSocketImpl.this.toString(), e);
       }
     }
 
@@ -267,7 +259,6 @@ class AFUNIXSocketImpl extends SocketImpl {
         NativeUnixSocket.shutdown(fd, SHUT_WR);
       }
       closedOutputStream = true;
-      checkClose();
     }
   }
 
@@ -289,7 +280,7 @@ class AFUNIXSocketImpl extends SocketImpl {
 
   private static int expectBoolean(Object value) throws SocketException {
     try {
-      return ((Boolean) value).booleanValue() ? 1 : 0;
+      return (Boolean) value ? 1 : 0;
     } catch (final ClassCastException e) {
       throw new AFUNIXSocketException("Unsupported value: " + value, e);
     } catch (final NullPointerException e) {
@@ -303,7 +294,7 @@ class AFUNIXSocketImpl extends SocketImpl {
       switch (optID) {
         case SocketOptions.SO_KEEPALIVE:
         case SocketOptions.TCP_NODELAY:
-          return NativeUnixSocket.getSocketOptionInt(fd, optID) != 0 ? true : false;
+          return NativeUnixSocket.getSocketOptionInt(fd, optID) != 0;
         case SocketOptions.SO_LINGER:
         case SocketOptions.SO_TIMEOUT:
         case SocketOptions.SO_RCVBUF:

--- a/junixsocket-common/src/main/java/org/newsclub/net/unix/NativeUnixSocket.java
+++ b/junixsocket-common/src/main/java/org/newsclub/net/unix/NativeUnixSocket.java
@@ -119,9 +119,6 @@ final class NativeUnixSocket {
     } catch (final RuntimeException e) {
       throw e;
     } catch (final Exception e) {
-      if (e instanceof AFUNIXSocketException) {
-        throw (AFUNIXSocketException) e;
-      }
       throw new AFUNIXSocketException("Could not set port", e);
     }
     if (!setOk) {

--- a/junixsocket-common/src/main/java/org/newsclub/net/unix/socketfactory/PostgresqlAFUNIXSocketFactory.java
+++ b/junixsocket-common/src/main/java/org/newsclub/net/unix/socketfactory/PostgresqlAFUNIXSocketFactory.java
@@ -1,0 +1,88 @@
+/**
+ * junixsocket
+ *
+ * Copyright (c) 2009,2014 Christian Kohlschütter
+ *
+ * The author licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.newsclub.net.unix.socketfactory;
+
+import org.newsclub.net.unix.AFUNIXSocket;
+import org.newsclub.net.unix.AFUNIXSocketAddress;
+
+import javax.net.SocketFactory;
+import java.io.File;
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.Socket;
+
+/**
+ * A simple {@link SocketFactory} which takes the connection path and port as constructor parameters.
+ * <p>
+ * This implementation breaks the SocketFactory-spec by returning a connected socket in the createSocket-method.
+ * This is necessary to work around some limitations in how the
+ * <a href="https://github.com/pgjdbc/pgjdbc">PGJDBC-library</a> uses a socket factory.
+ * </p>
+ * <p>
+ * To us this in pgjdbc, add the following to your connection-url:
+ * <code>
+ * &amp;socketFactory=org.newsclub.net.unix.socketfactory.PostgresqlAFUNIXSocketFactory&amp;socketFactoryArg=[path-to-the-unix-socket]
+ * For many distros the default path is /var/run/postgresql/.s.PGSQL.5432
+ * </code>
+ * </p>
+ */
+public class PostgresqlAFUNIXSocketFactory extends SocketFactory {
+
+  private final int port;
+  private final File file;
+
+  public PostgresqlAFUNIXSocketFactory(String path) {
+    this(path, 0);
+  }
+
+  public PostgresqlAFUNIXSocketFactory(String path, int port) {
+    this.file = new File(path);
+    this.port = port;
+  }
+
+
+  /**
+   * Creates a connected socket to the file/port given as constructor parameters.
+   */
+  @Override
+  public Socket createSocket() throws IOException {
+    AFUNIXSocket s = AFUNIXSocket.newInstance();
+    s.connect(new AFUNIXSocketAddress(file, port));
+    return s;
+  }
+
+  @Override
+  public Socket createSocket(String s, int i) throws IOException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Socket createSocket(String s, int i, InetAddress inetAddress, int i1) throws IOException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Socket createSocket(InetAddress inetAddress, int i) throws IOException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Socket createSocket(InetAddress inetAddress, int i, InetAddress inetAddress1, int i1) throws IOException {
+    throw new UnsupportedOperationException();
+  }
+}

--- a/junixsocket-common/src/main/java/org/newsclub/net/unix/socketfactory/SimpleAFUNIXSocketFactory.java
+++ b/junixsocket-common/src/main/java/org/newsclub/net/unix/socketfactory/SimpleAFUNIXSocketFactory.java
@@ -1,0 +1,60 @@
+/**
+ * junixsocket
+ *
+ * Copyright (c) 2009,2014 Christian Kohlschütter
+ *
+ * The author licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.newsclub.net.unix.socketfactory;
+
+import org.newsclub.net.unix.AFUNIXSocket;
+import org.newsclub.net.unix.AFUNIXSocketAddress;
+
+import javax.net.SocketFactory;
+import java.io.File;
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.Socket;
+
+/**
+ * A simple {@link SocketFactory} which returns {@link AFUNIXSocket}s.
+ */
+public class SimpleAFUNIXSocketFactory extends SocketFactory {
+
+  @Override
+  public Socket createSocket() throws IOException {
+    return AFUNIXSocket.newInstance();
+  }
+
+  @Override
+  public Socket createSocket(String s, int port) throws IOException {
+    AFUNIXSocket afunixSocket = AFUNIXSocket.newInstance();
+    afunixSocket.connect(new AFUNIXSocketAddress(new File(s), port));
+    return afunixSocket;
+  }
+
+  @Override
+  public Socket createSocket(String s, int i, InetAddress inetAddress, int i1) throws IOException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Socket createSocket(InetAddress inetAddress, int i) throws IOException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Socket createSocket(InetAddress inetAddress, int i, InetAddress inetAddress1, int i1) throws IOException {
+    throw new UnsupportedOperationException();
+  }
+}

--- a/junixsocket-demo/pom.xml
+++ b/junixsocket-demo/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>no.fiken.oss.junixsocket</groupId>
     <artifactId>junixsocket-parent</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.0.1-SNAPSHOT</version>
   </parent>
   <name>junixsocket-demo</name>
   <properties>

--- a/junixsocket-demo/pom.xml
+++ b/junixsocket-demo/pom.xml
@@ -4,10 +4,9 @@
   <artifactId>junixsocket-demo</artifactId>
   <packaging>jar</packaging>
   <parent>
-    <groupId>com.kohlschutter.junixsocket</groupId>
+    <groupId>no.fiken.oss.junixsocket</groupId>
     <artifactId>junixsocket-parent</artifactId>
-    <version>2.0.5-SNAPSHOT</version>
-    <relativePath>../pom.xml</relativePath>
+    <version>1.0.0-SNAPSHOT</version>
   </parent>
   <name>junixsocket-demo</name>
   <properties>
@@ -15,23 +14,23 @@
   </properties>
   <dependencies>
     <dependency>
-      <groupId>com.kohlschutter.junixsocket</groupId>
+      <groupId>${project.groupId}</groupId>
       <artifactId>junixsocket-native-common</artifactId>
       <!-- JNI bindings are expected to remain stable for 2.0.x releases -->
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.kohlschutter.junixsocket</groupId>
+      <groupId>${project.groupId}</groupId>
       <artifactId>junixsocket-common</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.kohlschutter.junixsocket</groupId>
+      <groupId>${project.groupId}</groupId>
       <artifactId>junixsocket-mysql</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.kohlschutter.junixsocket</groupId>
+      <groupId>${project.groupId}</groupId>
       <artifactId>junixsocket-rmi</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/junixsocket-demo/src/main/java/org/newsclub/net/unix/demo/SimpleTestClient.java
+++ b/junixsocket-demo/src/main/java/org/newsclub/net/unix/demo/SimpleTestClient.java
@@ -48,7 +48,7 @@ public class SimpleTestClient {
       System.out.println("Connected");
 
       try (InputStream is = sock.getInputStream(); //
-          OutputStream os = sock.getOutputStream();) {
+          OutputStream os = sock.getOutputStream()) {
 
         byte[] buf = new byte[128];
 

--- a/junixsocket-demo/src/test/java/org/newsclub/net/unix/BufferOverflowTest.java
+++ b/junixsocket-demo/src/test/java/org/newsclub/net/unix/BufferOverflowTest.java
@@ -100,7 +100,7 @@ public class BufferOverflowTest {
   public void readOverflow() throws Exception {
     Socket[] sockets = connectToServer();
     try (Socket serverSocket = sockets[0];//
-        Socket clientSocket = sockets[1];) {
+        Socket clientSocket = sockets[1]) {
 
       byte[] input = new byte[16];
       byte[] output = new byte[15];
@@ -118,7 +118,7 @@ public class BufferOverflowTest {
   public void writeOverflow() throws Exception {
     Socket[] sockets = connectToServer();
     try (Socket serverSocket = sockets[0]; //
-        Socket clientSocket = sockets[1];) {
+        Socket clientSocket = sockets[1]) {
 
       byte[] input = new byte[15];
       byte[] output = new byte[16];

--- a/junixsocket-mysql/pom.xml
+++ b/junixsocket-mysql/pom.xml
@@ -4,10 +4,9 @@
   <artifactId>junixsocket-mysql</artifactId>
   <packaging>jar</packaging>
   <parent>
-    <groupId>com.kohlschutter.junixsocket</groupId>
+    <groupId>no.fiken.oss.junixsocket</groupId>
     <artifactId>junixsocket-parent</artifactId>
-    <version>2.0.5-SNAPSHOT</version>
-    <relativePath>../pom.xml</relativePath>
+    <version>1.0.0-SNAPSHOT</version>
   </parent>
   <name>junixsocket-mysql</name>
   <properties>
@@ -15,7 +14,7 @@
   </properties>
   <dependencies>
     <dependency>
-      <groupId>com.kohlschutter.junixsocket</groupId>
+      <groupId>${project.groupId}</groupId>
       <artifactId>junixsocket-common</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/junixsocket-mysql/pom.xml
+++ b/junixsocket-mysql/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>no.fiken.oss.junixsocket</groupId>
     <artifactId>junixsocket-parent</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.0.1-SNAPSHOT</version>
   </parent>
   <name>junixsocket-mysql</name>
   <properties>

--- a/junixsocket-mysql/src/main/java/com/mysql/jdbc/SocketFactory.java
+++ b/junixsocket-mysql/src/main/java/com/mysql/jdbc/SocketFactory.java
@@ -4,14 +4,14 @@ package com.mysql.jdbc;
 // NOT TO BE INCLUDED IN FINAL PRODUCT BINARY
 public interface SocketFactory {
   // // Method descriptor #4 ()Ljava/net/Socket;
-  public abstract java.net.Socket afterHandshake() throws java.net.SocketException,
-      java.io.IOException;
+  java.net.Socket afterHandshake() throws
+          java.io.IOException;
 
   // Method descriptor #4 ()Ljava/net/Socket;
-  public abstract java.net.Socket beforeHandshake() throws java.net.SocketException,
-      java.io.IOException;
+  java.net.Socket beforeHandshake() throws
+          java.io.IOException;
 
   // Method descriptor #10 (Ljava/lang/String;ILjava/util/Properties;)Ljava/net/Socket;
-  public abstract java.net.Socket connect(java.lang.String arg0, int arg1, java.util.Properties arg2)
-      throws java.net.SocketException, java.io.IOException;
+  java.net.Socket connect(java.lang.String arg0, int arg1, java.util.Properties arg2)
+      throws java.io.IOException;
 }

--- a/junixsocket-mysql/src/main/java/org/newsclub/net/mysql/AFUNIXDatabaseSocketFactory.java
+++ b/junixsocket-mysql/src/main/java/org/newsclub/net/mysql/AFUNIXDatabaseSocketFactory.java
@@ -38,18 +38,18 @@ public class AFUNIXDatabaseSocketFactory implements SocketFactory {
   }
 
   @Override
-  public Socket afterHandshake() throws SocketException, IOException {
+  public Socket afterHandshake() throws IOException {
     return socket;
   }
 
   @Override
-  public Socket beforeHandshake() throws SocketException, IOException {
+  public Socket beforeHandshake() throws IOException {
     return socket;
   }
 
   @Override
-  public Socket connect(String host, int portNumber, Properties props) throws SocketException,
-      IOException {
+  public Socket connect(String host, int portNumber, Properties props) throws
+          IOException {
     // Adjust the path to your MySQL socket by setting the
     // "junixsocket.file" property
     // If no socket path is given, use the default: /tmp/mysql.sock

--- a/junixsocket-native-common/pom.xml
+++ b/junixsocket-native-common/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>no.fiken.oss.junixsocket</groupId>
     <artifactId>junixsocket-parent</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.0.1-SNAPSHOT</version>
   </parent>
   <name>junixsocket-native-common</name>
   <properties>

--- a/junixsocket-native-common/pom.xml
+++ b/junixsocket-native-common/pom.xml
@@ -5,11 +5,9 @@
   <artifactId>junixsocket-native-common</artifactId>
   <packaging>jar</packaging>
   <parent>
-    <groupId>com.kohlschutter.junixsocket</groupId>
+    <groupId>no.fiken.oss.junixsocket</groupId>
     <artifactId>junixsocket-parent</artifactId>
-    <!-- Update this manually after maven-release -->
-    <version>2.0.5-SNAPSHOT</version>
-    <relativePath>../pom.xml</relativePath>
+    <version>1.0.0-SNAPSHOT</version>
   </parent>
   <name>junixsocket-native-common</name>
   <properties>
@@ -29,7 +27,7 @@
             <configuration>
               <artifactSet>
                 <includes>
-                  <include>com.kohlschutter.junixsocket:junixsocket-native</include>
+                  <include>${project.groupId}:junixsocket-native</include>
                 </includes>
               </artifactSet>
               <promoteTransitiveDependencies>true</promoteTransitiveDependencies>
@@ -47,12 +45,12 @@
   </build>
   <dependencies>
     <dependency>
-      <groupId>com.kohlschutter.junixsocket</groupId>
+      <groupId>${project.groupId}</groupId>
       <artifactId>junixsocket-common</artifactId>
       <version>${project.parent.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.kohlschutter.junixsocket</groupId>
+      <groupId>${project.groupId}</groupId>
       <artifactId>junixsocket-native</artifactId>
       <version>${project.version}</version>
       <type>nar</type>
@@ -71,7 +69,7 @@
       </activation>
       <dependencies>
         <dependency>
-          <groupId>com.kohlschutter.junixsocket</groupId>
+          <groupId>${project.groupId}</groupId>
           <artifactId>junixsocket-native</artifactId>
           <version>${project.version}</version>
           <type>nar</type>
@@ -89,7 +87,7 @@
       </activation>
       <dependencies>
         <dependency>
-          <groupId>com.kohlschutter.junixsocket</groupId>
+          <groupId>${project.groupId}</groupId>
           <artifactId>junixsocket-native</artifactId>
           <version>${project.version}</version>
           <type>nar</type>
@@ -101,14 +99,14 @@
       <id>release</id>
       <dependencies>
         <dependency>
-          <groupId>com.kohlschutter.junixsocket</groupId>
+          <groupId>${project.groupId}</groupId>
           <artifactId>junixsocket-native</artifactId>
           <version>${project.version}</version>
           <type>nar</type>
           <classifier>x86_64-MacOSX-gpp-jni</classifier>
         </dependency>
         <dependency>
-          <groupId>com.kohlschutter.junixsocket</groupId>
+          <groupId>${project.groupId}</groupId>
           <artifactId>junixsocket-native</artifactId>
           <version>${project.version}</version>
           <type>nar</type>

--- a/junixsocket-native/pom.xml
+++ b/junixsocket-native/pom.xml
@@ -5,10 +5,9 @@
   <artifactId>junixsocket-native</artifactId>
   <packaging>nar</packaging>
   <parent>
-    <groupId>com.kohlschutter.junixsocket</groupId>
+    <groupId>no.fiken.oss.junixsocket</groupId>
     <artifactId>junixsocket-parent</artifactId>
-    <version>2.0.5-SNAPSHOT</version>
-    <relativePath>../pom.xml</relativePath>
+    <version>1.0.0-SNAPSHOT</version>
   </parent>
   <name>junixsocket-native</name>
   <properties>

--- a/junixsocket-native/pom.xml
+++ b/junixsocket-native/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>no.fiken.oss.junixsocket</groupId>
     <artifactId>junixsocket-parent</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.0.1-SNAPSHOT</version>
   </parent>
   <name>junixsocket-native</name>
   <properties>

--- a/junixsocket-native/src/main/c/org_newsclub_net_unix_NativeUnixSocket.c
+++ b/junixsocket-native/src/main/c/org_newsclub_net_unix_NativeUnixSocket.c
@@ -387,7 +387,6 @@ JNIEXPORT jint JNICALL Java_org_newsclub_net_unix_NativeUnixSocket_write(
 	}
 
 	jsize jbufLen = (*env)->GetArrayLength(env, jbuf);
-	fprintf(stderr, "jbufLen: %d\n", jbufLen);
 
 	if(length > jbufLen - offset) {
 		org_newsclub_net_unix_NativeUnixSocket_throwIndexOutOfBoundsException(

--- a/junixsocket-rmi/pom.xml
+++ b/junixsocket-rmi/pom.xml
@@ -4,10 +4,9 @@
   <artifactId>junixsocket-rmi</artifactId>
   <packaging>jar</packaging>
   <parent>
-    <groupId>com.kohlschutter.junixsocket</groupId>
+    <groupId>no.fiken.oss.junixsocket</groupId>
     <artifactId>junixsocket-parent</artifactId>
-    <version>2.0.5-SNAPSHOT</version>
-    <relativePath>../pom.xml</relativePath>
+    <version>1.0.0-SNAPSHOT</version>
   </parent>
   <name>junixsocket-rmi</name>
   <properties>
@@ -15,7 +14,7 @@
   </properties>
   <dependencies>
     <dependency>
-      <groupId>com.kohlschutter.junixsocket</groupId>
+      <groupId>${project.groupId}</groupId>
       <artifactId>junixsocket-common</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/junixsocket-rmi/pom.xml
+++ b/junixsocket-rmi/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>no.fiken.oss.junixsocket</groupId>
     <artifactId>junixsocket-parent</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.0.1-SNAPSHOT</version>
   </parent>
   <name>junixsocket-rmi</name>
   <properties>

--- a/junixsocket-rmi/src/main/java/org/newsclub/net/unix/rmi/AFUNIXNaming.java
+++ b/junixsocket-rmi/src/main/java/org/newsclub/net/unix/rmi/AFUNIXNaming.java
@@ -169,7 +169,7 @@ public final class AFUNIXNaming {
       try {
         assigner = (PortAssigner) lookup(PORT_ASSIGNER_ID);
       } catch (MalformedURLException e) {
-        throw (RemoteException) new RemoteException(e.getMessage()).initCause(e);
+        throw new RemoteException(e.getMessage(), e);
       }
       return assigner;
     }
@@ -211,7 +211,7 @@ public final class AFUNIXNaming {
    * Shuts this RMI Registry down. Before calling this method, you have to unexport all existing
    * bindings, otherwise the "RMI Reaper" thread will not be closed.
    */
-  public void shutdownRegistry() throws AccessException, RemoteException, IOException {
+  public void shutdownRegistry() throws IOException {
     try {
       getRegistry().unbind(PORT_ASSIGNER_ID);
       UnicastRemoteObject.unexportObject(portAssigner, true);
@@ -232,7 +232,7 @@ public final class AFUNIXNaming {
       try {
         this.socketDir = socketDir.getCanonicalFile();
       } catch (IOException e) {
-        throw (RemoteException) new RemoteException(e.getMessage()).initCause(e);
+        throw new RemoteException(e.getMessage(), e);
       }
       this.port = port;
     }

--- a/junixsocket-rmi/src/main/java/org/newsclub/net/unix/rmi/AFUNIXRMISocketFactory.java
+++ b/junixsocket-rmi/src/main/java/org/newsclub/net/unix/rmi/AFUNIXRMISocketFactory.java
@@ -133,7 +133,7 @@ public class AFUNIXRMISocketFactory extends RMISocketFactory implements External
       try {
         generator = naming.getPortAssigner();
       } catch (NotBoundException e) {
-        throw (IOException) new IOException(e.getMessage()).initCause(e);
+        throw new IOException(e.getMessage(), e);
       }
     }
     return generator.newPort();
@@ -144,7 +144,7 @@ public class AFUNIXRMISocketFactory extends RMISocketFactory implements External
       try {
         generator = naming.getPortAssigner();
       } catch (NotBoundException e) {
-        throw (IOException) new IOException(e.getMessage()).initCause(e);
+        throw new IOException(e.getMessage(), e);
       }
     }
     generator.returnPort(port);

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>no.fiken.oss.junixsocket</groupId>
   <artifactId>junixsocket-parent</artifactId>
-  <version>1.0.0-SNAPSHOT</version>
+  <version>1.0.1-SNAPSHOT</version>
   <packaging>pom</packaging>
   <parent>
     <groupId>com.kohlschutter</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -2,15 +2,14 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>com.kohlschutter.junixsocket</groupId>
+  <groupId>no.fiken.oss.junixsocket</groupId>
   <artifactId>junixsocket-parent</artifactId>
-  <version>2.0.5-SNAPSHOT</version>
+  <version>1.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <parent>
     <groupId>com.kohlschutter</groupId>
     <artifactId>kohlschutter-parent</artifactId>
     <version>1.1</version>
-    <relativePath>../kohlschutter-parent/pom.xml</relativePath>
   </parent>
   <name>junixsocket-parent</name>
   <inceptionYear>2009</inceptionYear>


### PR DESCRIPTION
This significantly improves performance when dealing with large arrays as it prevents one extra copy operation of the array. The downside is 64k of extra stack usage. Reads are limited to this 64k buffer instead of copying everything in one go. When changing from the current implementation to this version we saw an 6x performance gain for 10MB arrays.

This follows the same pattern as OpenJDK 8 uses:
http://hg.openjdk.java.net/jdk8/jdk8/jdk/file/687fd7c7986d/src/solaris/native/java/net/SocketInputStream.c
http://hg.openjdk.java.net/jdk8/jdk8/jdk/file/687fd7c7986d/src/solaris/native/java/net/SocketOutputStream.c