### PR TITLE
Java critical versions of read and write methods

### DIFF
--- a/junixsocket-benchmarks/pom.xml
+++ b/junixsocket-benchmarks/pom.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>junixsocket-benchmarks</artifactId>
+  <packaging>jar</packaging>
+  <parent>
+    <groupId>com.kohlschutter.junixsocket</groupId>
+    <artifactId>junixsocket-parent</artifactId>
+    <version>2.0.5-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+  <name>junixsocket-benchmarks</name>
+  <properties>
+    <kohlschutter.project.base.directory>${project.parent.basedir}</kohlschutter.project.base.directory>
+    <jmh.version>1.12</jmh.version>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>com.kohlschutter.junixsocket</groupId>
+      <artifactId>junixsocket-native-common</artifactId>
+      <!-- JNI bindings are expected to remain stable for 2.0.x releases -->
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.kohlschutter.junixsocket</groupId>
+      <artifactId>junixsocket-common</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.openjdk.jmh</groupId>
+      <artifactId>jmh-core</artifactId>
+      <version>${jmh.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.openjdk.jmh</groupId>
+      <artifactId>jmh-generator-annprocess</artifactId>
+      <version>${jmh.version}</version>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
+
+
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>2.2</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <finalName>microbenchmarks</finalName>
+              <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                  <mainClass>org.openjdk.jmh.Main</mainClass>
+                </transformer>
+              </transformers>
+              <filters>
+                <filter>
+                  <artifact>*:*</artifact>
+                  <excludes>
+                    <exclude>META-INF/services/javax.annotation.processing.Processor</exclude>
+                  </excludes>
+                </filter>
+              </filters>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/junixsocket-benchmarks/src/main/java/org/newsclub/net/unix/benchamrks/AFUNIXSocketBenchmarkRead.java
+++ b/junixsocket-benchmarks/src/main/java/org/newsclub/net/unix/benchamrks/AFUNIXSocketBenchmarkRead.java
@@ -1,0 +1,96 @@
+/**
+ * junixsocket
+ *
+ * Copyright (c) 2009,2014 Christian Kohlschütter
+ *
+ * The author licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.newsclub.net.unix.benchamrks;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.Socket;
+import java.util.concurrent.TimeUnit;
+
+import org.newsclub.net.unix.AFUNIXServerSocket;
+import org.newsclub.net.unix.AFUNIXSocketAddress;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+//to run this benchmark use 
+//while true; do socat UNIX:/tmp/junixsocket-test.sock /dev/zero 2> /dev/null; done
+@BenchmarkMode(Mode.AverageTime)
+@Fork(3)
+@State(Scope.Benchmark)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 3, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+public class AFUNIXSocketBenchmarkRead {
+
+	private byte[] bytes;
+	private InputStream is;
+	private Socket sock;
+
+	@Param({ "1", "100" })
+	public int payload;
+	private AFUNIXServerSocket server;
+
+	@Setup
+	public void setup() throws IOException {
+		final File file = new File(new File(System.getProperty("java.io.tmpdir")),
+				"junixsocket-test.sock");
+
+		AFUNIXSocketAddress address = new AFUNIXSocketAddress(file);
+		server = AFUNIXServerSocket.newInstance();
+		server.bind(address);
+		sock = server.accept();
+		is = sock.getInputStream();
+		bytes = new byte[payload];
+
+	}
+
+	@Benchmark
+	public int read() throws IOException {
+		return is.read(bytes);
+	}
+
+	@TearDown
+	public void tearDown() throws IOException {
+		is.close();
+		sock.close();
+		server.close();
+	}
+
+	public static void main(String[] args) throws RunnerException {
+		Options opt = new OptionsBuilder().include(".*" + AFUNIXSocketBenchmarkRead.class.getSimpleName()
+				+ ".*").build();
+
+		new Runner(opt).run();
+	}
+
+}

--- a/junixsocket-benchmarks/src/main/java/org/newsclub/net/unix/benchamrks/AFUNIXSocketBenchmarkWrite.java
+++ b/junixsocket-benchmarks/src/main/java/org/newsclub/net/unix/benchamrks/AFUNIXSocketBenchmarkWrite.java
@@ -1,0 +1,96 @@
+/**
+ * junixsocket
+ *
+ * Copyright (c) 2009,2014 Christian Kohlschütter
+ *
+ * The author licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.newsclub.net.unix.benchamrks;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+import org.newsclub.net.unix.AFUNIXSocket;
+import org.newsclub.net.unix.AFUNIXSocketAddress;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+
+//to run this benchmark use 
+//while true; do socat UNIX-LISTEN:/tmp/junixsocket-test.sock /dev/null; done
+@BenchmarkMode(Mode.AverageTime)
+@Fork(3)
+@State(Scope.Benchmark)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 3, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+public class AFUNIXSocketBenchmarkWrite {
+
+  private byte[] bytes;
+  private OutputStream os;
+
+  @Param({"1", "100"})
+  public int payload;
+  private AFUNIXSocket client;
+
+  @Setup
+  public void setup() throws IOException {
+    final File file = new File(new File(System.getProperty("java.io.tmpdir")),
+        "junixsocket-test.sock");
+
+    AFUNIXSocketAddress address = new AFUNIXSocketAddress(file);
+    client = AFUNIXSocket.newInstance();
+    client.connect(address);
+    os = client.getOutputStream();
+
+    bytes = new byte[payload];
+    new Random(228L).nextBytes(bytes);
+  }
+
+  @Benchmark
+  public void write() throws IOException {
+    os.write(bytes);
+    os.flush();
+  }
+
+  @TearDown
+  public void tearDown() throws IOException {
+    os.close();
+    client.close();
+  }
+
+  public static void main(String[] args) throws RunnerException {
+    Options opt = new OptionsBuilder().include(".*" + AFUNIXSocketBenchmarkWrite.class.getSimpleName()
+        + ".*").build();
+
+    new Runner(opt).run();
+  }
+
+}

--- a/junixsocket-common/src/main/java/org/newsclub/net/unix/NativeUnixSocket.java
+++ b/junixsocket-common/src/main/java/org/newsclub/net/unix/NativeUnixSocket.java
@@ -51,6 +51,8 @@ final class NativeUnixSocket {
   static void checkSupported() {
   }
 
+  static native int getInfFd(final FileDescriptor fd) throws IOException;
+  
   static native void bind(final String socketFile, final FileDescriptor fd, final int backlog)
       throws IOException;
 
@@ -61,9 +63,9 @@ final class NativeUnixSocket {
 
   static native void connect(final String socketFile, final FileDescriptor fd) throws IOException;
 
-  static native int read(final FileDescriptor fd, byte[] buf, int off, int len) throws IOException;
+  static native int read(int intFd, byte[] buf, int off, int len);
 
-  static native int write(final FileDescriptor fd, byte[] buf, int off, int len) throws IOException;
+  static native int write(int intFd, byte[] buf, int off, int len);
 
   static native void close(final FileDescriptor fd) throws IOException;
 

--- a/junixsocket-native/src/main/c/org_newsclub_net_unix_NativeUnixSocket.h
+++ b/junixsocket-native/src/main/c/org_newsclub_net_unix_NativeUnixSocket.h
@@ -7,6 +7,10 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+
+JNIEXPORT jint JNICALL Java_org_newsclub_net_unix_NativeUnixSocket_getInfFd
+  (JNIEnv * env, jclass clazz, jobject fd);
 /*
  * Class:     org_newsclub_net_unix_NativeUnixSocket
  * Method:    bind
@@ -42,18 +46,34 @@ JNIEXPORT void JNICALL Java_org_newsclub_net_unix_NativeUnixSocket_connect
 /*
  * Class:     org_newsclub_net_unix_NativeUnixSocket
  * Method:    read
- * Signature: (Ljava/io/FileDescriptor;[BII)I
+ * Signature: (I;[BII)I
  */
 JNIEXPORT jint JNICALL Java_org_newsclub_net_unix_NativeUnixSocket_read
-  (JNIEnv *, jclass, jobject, jbyteArray, jint, jint);
+  (JNIEnv *, jclass, jint, jbyteArray, jint, jint);
 
 /*
  * Class:     org_newsclub_net_unix_NativeUnixSocket
  * Method:    write
- * Signature: (Ljava/io/FileDescriptor;[BII)I
+ * Signature: (I;[BII)I
  */
 JNIEXPORT jint JNICALL Java_org_newsclub_net_unix_NativeUnixSocket_write
-  (JNIEnv *, jclass, jobject, jbyteArray, jint, jint);
+  (JNIEnv *, jclass, jint, jbyteArray, jint, jint);
+
+/*
+ * Class:     org_newsclub_net_unix_NativeUnixSocket
+ * Method:    read
+ * Signature: (I;[BII)I
+ */
+JNIEXPORT jint JNICALL JavaCritical_org_newsclub_net_unix_NativeUnixSocket_read
+  (jint, jint, jbyte*, jint, jint);
+
+/*
+ * Class:     org_newsclub_net_unix_NativeUnixSocket
+ * Method:    write
+ * Signature: (I;[BII)I
+ */
+JNIEXPORT jint JNICALL JavaCritical_org_newsclub_net_unix_NativeUnixSocket_write
+  (jint, jint, jbyte*, jint, jint);
 
 /*
  * Class:     org_newsclub_net_unix_NativeUnixSocket

--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,7 @@ In contrast to other implementations, junixsocket extends the Java Sockets API (
     <module>junixsocket-rmi</module>
     <module>junixsocket-mysql</module>
     <module>junixsocket-demo</module>
+    <module>junixsocket-benchmarks</module>
   </modules>
 
   <profiles>


### PR DESCRIPTION
Currrently this library uses JNI for native functions. There is an alternative described here:
http://stackoverflow.com/questions/36298111/is-it-possible-to-use-sun-misc-unsafe-to-call-c-functions-without-jni/36309652#36309652

Since it is a perfomance-only change I first added benchmarks module and got the following results:

```
Benchmark                       (payload)  Mode  Cnt    Score    Error  Units
AFUNIXSocketBenchmarkRead.read          1  avgt   15  407.767 ± 17.430  ns/op
AFUNIXSocketBenchmarkRead.read        100  avgt   15  432.175 ± 12.192  ns/op
AFUNIXSocketBenchmarkWrite.write        1  avgt   15  669.619 ± 10.605  ns/op
AFUNIXSocketBenchmarkWrite.write      100  avgt   15  810.941 ± 146.036 ns/op
```

I rewrote read() and write() (two most used and performance-sensitive) methods with Java_critical and now benchmarks show these numbers:

```
Benchmark                       (payload)  Mode  Cnt    Score   Error  Units
AFUNIXSocketBenchmarkRead.read          1  avgt   15  174.881 ± 8.614  ns/op
AFUNIXSocketBenchmarkRead.read        100  avgt   15  195.699 ± 4.868  ns/op
AFUNIXSocketBenchmarkWrite.write        1  avgt   15  454.171 ± 9.514  ns/op
AFUNIXSocketBenchmarkWrite.write      100  avgt   15  470.008 ± 14.117 ns/op
```

Note: to benchmark them separately I used `socat` linux tool as described in benchmarks comments.
