### PR TITLE
Close underlying native socket when socket object is no longer referenced

### DIFF
--- a/junixsocket-common/src/main/java/org/newsclub/net/unix/AFUNIXSocketImpl.java
+++ b/junixsocket-common/src/main/java/org/newsclub/net/unix/AFUNIXSocketImpl.java
@@ -407,5 +407,10 @@ class AFUNIXSocketImpl extends SocketImpl {
         }
       }
     }
+
+    @Override
+    protected void finalize() throws IOException {
+        close();
+    }
   }
 }


### PR DESCRIPTION
This avoid descriptor leak when all references to socket object are lost.
Simple example to reproduce the problem:

```
public static void main(String[] args) throws IOException {
    Socket socket = AFUNIXSocket.newInstance();
    socket.connect(new AFUNIXSocketAddress(new File("test.sock")), 10000);
    socket.getOutputStream().write("test\n".getBytes());

    while(true) {
        // create some pressure on GC
        String s = new String("test".getBytes());
    }
}
```

Without finalize() this simple code leaks a file descriptor and it is not possible to close it afterwards in any way.
