### PR TITLE
junixsocket 2.1.1

### DIFF
--- a/junixsocket-common/pom.xml
+++ b/junixsocket-common/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>com.kohlschutter.junixsocket</groupId>
     <artifactId>junixsocket-parent</artifactId>
-    <version>2.1.0</version>
+    <version>2.1.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <name>junixsocket-common</name>

--- a/junixsocket-core/pom.xml
+++ b/junixsocket-core/pom.xml
@@ -11,7 +11,7 @@
   <parent>
     <groupId>com.kohlschutter.junixsocket</groupId>
     <artifactId>junixsocket-parent</artifactId>
-    <version>2.1.0</version>
+    <version>2.1.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <name>junixsocket-core</name>

--- a/junixsocket-demo/pom.xml
+++ b/junixsocket-demo/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>com.kohlschutter.junixsocket</groupId>
     <artifactId>junixsocket-parent</artifactId>
-    <version>2.1.0</version>
+    <version>2.1.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <name>junixsocket-demo</name>

--- a/junixsocket-dist/pom.xml
+++ b/junixsocket-dist/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>com.kohlschutter.junixsocket</groupId>
     <artifactId>junixsocket-parent</artifactId>
-    <version>2.1.0</version>
+    <version>2.1.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <name>junixsocket-dist</name>

--- a/junixsocket-mysql/pom.xml
+++ b/junixsocket-mysql/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>com.kohlschutter.junixsocket</groupId>
     <artifactId>junixsocket-parent</artifactId>
-    <version>2.1.0</version>
+    <version>2.1.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <name>junixsocket-mysql</name>

--- a/junixsocket-native-common/pom.xml
+++ b/junixsocket-native-common/pom.xml
@@ -9,7 +9,7 @@
     <groupId>com.kohlschutter.junixsocket</groupId>
     <artifactId>junixsocket-parent</artifactId>
     <!-- Update this manually after maven-release -->
-    <version>2.1.0</version>
+    <version>2.1.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <name>junixsocket-native-common</name>

--- a/junixsocket-native-custom/pom.xml
+++ b/junixsocket-native-custom/pom.xml
@@ -9,7 +9,7 @@
     <groupId>com.kohlschutter.junixsocket</groupId>
     <artifactId>junixsocket-parent</artifactId>
     <!-- Update this manually after maven-release -->
-    <version>2.1.0</version>
+    <version>2.1.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <name>junixsocket-native-common</name>

--- a/junixsocket-native/pom.xml
+++ b/junixsocket-native/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>com.kohlschutter.junixsocket</groupId>
     <artifactId>junixsocket-parent</artifactId>
-    <version>2.1.0</version>
+    <version>2.1.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <name>junixsocket-native</name>

--- a/junixsocket-rmi/pom.xml
+++ b/junixsocket-rmi/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.kohlschutter.junixsocket</groupId>
     <artifactId>junixsocket-parent</artifactId>
-    <version>2.1.0</version>
+    <version>2.1.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <name>junixsocket-rmi</name>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.kohlschutter.junixsocket</groupId>
   <artifactId>junixsocket-parent</artifactId>
-  <version>2.1.0</version>
+  <version>2.1.1</version>
   <packaging>pom</packaging>
   <parent>
     <groupId>com.kohlschutter</groupId>

--- a/src/site/markdown/changelog.md
+++ b/src/site/markdown/changelog.md
@@ -1,5 +1,9 @@
 ### Noteworthy changes
 
+  * _(2018-12-26)_ **junixsocket 2.1.1**
+  
+    - Add missing library for Linux 64-bit to junixsocket-native-common (Maven only)
+
   * _(2018-12-26)_ **junixsocket 2.1.0**
   
     - Support for Java 8, 9, 10 and 11

--- a/src/site/markdown/dependency.md
+++ b/src/site/markdown/dependency.md
@@ -5,7 +5,7 @@ Add the following dependency to your Maven project
     <dependency>
       <groupId>com.kohlschutter.junixsocket</groupId>
       <artifactId>junixsocket-core</artifactId>
-      <version>2.1.0</version>
+      <version>2.1.1</version>
     </dependency>
 
 ([See here](customarch.html) how to add support for custom architectures that aren't supported out of the box).
@@ -15,7 +15,7 @@ If you're going to use RMI over Unix sockets, add the following dependency:
     <dependency>
       <groupId>com.kohlschutter.junixsocket</groupId>
       <artifactId>junixsocket-rmi</artifactId>
-      <version>2.1.0</version>
+      <version>2.1.1</version>
     </dependency>
 
 If you're going to use the mySQL Connector for Unix sockets, add the following dependency:
@@ -23,20 +23,20 @@ If you're going to use the mySQL Connector for Unix sockets, add the following d
     <dependency>
       <groupId>com.kohlschutter.junixsocket</groupId>
       <artifactId>junixsocket-mysql</artifactId>
-      <version>2.1.0</version>
+      <version>2.1.1</version>
     </dependency>
  
 # Gradle
  
  Minimum requirement:
  
-    compile 'com.kohlschutter.junixsocket:junixsocket-core:2.1.0'
+    compile 'com.kohlschutter.junixsocket:junixsocket-core:2.1.1'
  
  For RMI support, add:
  
-    compile 'com.kohlschutter.junixsocket:junixsocket-rmi:2.1.0'
+    compile 'com.kohlschutter.junixsocket:junixsocket-rmi:2.1.1'
  
  For MySQL support, add:
  
-    compile 'com.kohlschutter.junixsocket:junixsocket-mysql:2.1.0'
+    compile 'com.kohlschutter.junixsocket:junixsocket-mysql:2.1.1'
  

--- a/src/site/markdown/release.md
+++ b/src/site/markdown/release.md
@@ -102,7 +102,7 @@ The files can be found in
   
     cd junixsocket
     mvn clean install -Pstrict -Prelease
-    mvn deploy -Psigned
+    mvn deploy -Pstrict -Prelease -Psigned
     
 ##### Notes
 
@@ -128,14 +128,28 @@ For example:
     The URL of the staging repository is `https://oss.sonatype.org/content/groups/staging`.
     The artifacts can be found [here](https://oss.sonatype.org/content/groups/staging/com/kohlschutter/junixsocket/).
 
+**IMPORTANT** Double-check that the staged junixsocket-native-common artifact contains both macOS
+and Linux 64-bit libraries. 
+
 #### 3. Release artifact to Maven Central
+  
+**IMPORTANT** Once released, it cannot be undone! Make sure you verify the staged artifact first!
   
     mvn nexus-staging:release     
 
 ### Tag the release, push to upstream (i.e., GitHub)
 
     mvn scm:tag
-    git push
+
+### Release on GitHub
+    
+1. Log in to GitHub, go to Releases -> Draft a new release.
+
+2. Select the newly created tag (= search for the version).
+
+3. Release title = "junixsocket" + version>, e.g., "junixsocket 2.1.0"
+
+4. Hit "Publish release"    
 
 ### Publish website 
 

--- a/src/site/markdown/release.md
+++ b/src/site/markdown/release.md
@@ -88,7 +88,7 @@ a script to run the demo classes from the command-line.
 
     cd junixsocket
     mvn clean install -Pstrict -Prelease
-    ( cd junixsocket-dist ; mvn assembly:single )
+    ( cd junixsocket-dist ; mvn assembly:single -Prelease -Pstrict )
 
 The files can be found in
 


### PR DESCRIPTION
2.1.0 was an incomplete release (missing the library for 64-bit Linux), please ignore.
