### PR TITLE
Add support for Linux on PowerPC 64-bit LE (ppc64le)

### DIFF
--- a/junixsocket-common/src/test/java/org/newsclub/net/unix/AcceptTimeoutTest.java
+++ b/junixsocket-common/src/test/java/org/newsclub/net/unix/AcceptTimeoutTest.java
@@ -66,7 +66,7 @@ public class AcceptTimeoutTest extends SocketTestBase {
 
   @Test
   public void testTimeoutAfterDelay() throws Exception {
-    final int timeoutMillis = 250;
+    final int timeoutMillis = 252;
     assertTimeoutPreemptively(Duration.ofMillis(2 * timeoutMillis), () -> {
       try (AFUNIXServerSocket sock = startServer()) {
         final int connectDelayMillis = 50;

--- a/junixsocket-native-common/pom.xml
+++ b/junixsocket-native-common/pom.xml
@@ -142,6 +142,15 @@
           <artifactId>junixsocket-native</artifactId>
           <version>${project.version}</version>
           <type>nar</type>
+          <classifier>ppc64le-Linux-clang-llvm-jni</classifier>
+          <scope>runtime</scope>
+          <optional>true</optional>
+        </dependency>
+        <dependency>
+          <groupId>com.kohlschutter.junixsocket</groupId>
+          <artifactId>junixsocket-native</artifactId>
+          <version>${project.version}</version>
+          <type>nar</type>
           <classifier>amd64-Windows10-clang-llvm-jni</classifier>
           <scope>runtime</scope>
           <optional>true</optional>

--- a/junixsocket-native-cross/pom.xml
+++ b/junixsocket-native-cross/pom.xml
@@ -205,6 +205,37 @@
               </properties>
             </configuration>
           </execution>
+          <execution>
+            <id>crosscompile-ppc64le-Linux-clang</id>
+            <goals>
+              <goal>run</goal>
+            </goals>
+            <configuration>
+              <skipInvocation>${junixsocket.cross.disabled}</skipInvocation>
+              <noLog>true</noLog>
+              <streamLogs>true</streamLogs>
+              <goals>
+                <goal>clean</goal>
+                <goal>install</goal>
+              </goals>
+              <projectsDirectory>${project.basedir}/../</projectsDirectory>
+              <pomIncludes>
+                <pomInclude>junixsocket-native</pomInclude>
+              </pomIncludes>
+              <profiles>
+                <profile>llvm</profile>
+              </profiles>
+              <properties>
+                <junixsocket.native.aol.llvm>ppc64le-Linux-clang</junixsocket.native.aol.llvm>
+                <junixsocket.install.skip>true</junixsocket.install.skip>
+                <junixsocket.build.directory>${project.build.directory}/junixsocket-native-ppc64le-Linux-clang-llvm</junixsocket.build.directory>
+                <junixsocket.native.llvm.target>powerpc64le-linux-gnu</junixsocket.native.llvm.target>
+                <junixsocket.native.jnilib.extension>so</junixsocket.native.jnilib.extension>
+                <junixsocket.common.classifier.linux.ppc>ppc64le-Linux-clang-llvm-jni</junixsocket.common.classifier.linux.ppc>
+                <ignorant>${ignorant}</ignorant>
+              </properties>
+            </configuration>
+          </execution>
         </executions>
       </plugin>
 
@@ -288,6 +319,22 @@
               <version>${project.version}</version>
               <packaging>nar</packaging>
               <classifier>aarch64-Linux-clang-llvm-jni</classifier>
+              <generatePom>false</generatePom>
+            </configuration>
+          </execution>
+          <execution>
+            <id>install-ppc64le-Linux-clang</id>
+            <phase>install</phase>
+            <goals>
+              <goal>install-file</goal>
+            </goals>
+            <configuration>
+              <file>${project.build.directory}/junixsocket-native-ppc64le-Linux-clang-llvm/junixsocket-native-${project.version}-ppc64le-Linux-clang-jni.nar</file>
+              <groupId>${project.groupId}</groupId>
+              <artifactId>junixsocket-native</artifactId>
+              <version>${project.version}</version>
+              <packaging>nar</packaging>
+              <classifier>ppc64le-Linux-clang-llvm-jni</classifier>
               <generatePom>false</generatePom>
             </configuration>
           </execution>

--- a/junixsocket-native/src/main/c/org_newsclub_net_unix_NativeUnixSocket.c
+++ b/junixsocket-native/src/main/c/org_newsclub_net_unix_NativeUnixSocket.c
@@ -194,7 +194,7 @@ static int CAPABILITY_ABSTRACT_NAMESPACE = (1 << 3);
 static void org_newsclub_net_unix_NativeUnixSocket_throwException(JNIEnv* env,
         ExceptionType exceptionType, char* message)
 {
-    if(exceptionType < 0 || exceptionType >= kExceptionMaxExcl) {
+    if(exceptionType >= kExceptionMaxExcl) {
         exceptionType = kExceptionIllegalStateException;
     }
     const char *exceptionClass = kExceptionClasses[exceptionType];

--- a/junixsocket-native/src/main/nar/aol.properties
+++ b/junixsocket-native/src/main/nar/aol.properties
@@ -91,6 +91,28 @@ aarch64.Linux.clang.cpp.options=${junixsocket.native.clang.cpp.options} -target 
 aarch64.Linux.clang.cpp.includes=${junixsocket.native.default.cpp.includes}
 aarch64.Linux.clang.cpp.excludes=
 
+ppc64le.Linux.clang.linker.name=clang
+ppc64le.Linux.clang.linker.options=-nostdlib -Xcrossclang-with-and-without-lc -target ${junixsocket.native.llvm.target}
+ppc64le.Linux.clang.c.compiler=clang
+ppc64le.Linux.clang.c.defines=_GNU_SOURCE
+ppc64le.Linux.clang.c.options=${junixsocket.native.clang.c.options} -I${project.basedir}/src/main/c/jni -target ${junixsocket.native.llvm.target}
+ppc64le.Linux.clang.c.includes=${junixsocket.native.default.c.includes}
+ppc64le.Linux.clang.c.excludes=
+ppc64le.Linux.clang.java.include=
+ppc64le.Linux.clang.java.runtimeDirectory=IGNORED
+ppc64le.Linux.clang.lib.prefix=lib
+ppc64le.Linux.clang.shared.prefix=lib
+ppc64le.Linux.clang.static.extension=a
+ppc64le.Linux.clang.shared.extension=so
+ppc64le.Linux.clang.plugin.extension=so
+ppc64le.Linux.clang.jni.extension=so
+ppc64le.Linux.clang.executable.extension=
+ppc64le.Linux.clang.cpp.compiler=clang++
+ppc64le.Linux.clang.cpp.defines=_GNU_SOURCE
+ppc64le.Linux.clang.cpp.options=${junixsocket.native.clang.cpp.options} -target ${junixsocket.native.llvm.target}
+ppc64le.Linux.clang.cpp.includes=${junixsocket.native.default.cpp.includes}
+ppc64le.Linux.clang.cpp.excludes=
+
 amd64.Windows10.clang.linker.name=clang
 amd64.Windows10.clang.linker.options=-target unspecified -Xcrossclang-use-gcc=x86_64-w64-mingw32-gcc -lWs2_32 -lAdvApi32 -lMswsock -Xcrossclang-output-strip-lib-prefix
 #amd64.Windows10.clang.linker.options=-target ${junixsocket.native.llvm.target} -Xcrossclang-use-ldshim -Wl,--Xldshim-ld=x86_64-w64-mingw32-ld


### PR DESCRIPTION
Tested on openSUSE Leap 15.0 with Java 11, llvm8 from OBS project
devel:tools:compiler, and SLES12-SP4 ppc64le in a QEMU VM with
SLE SDK and llvm6.

**Note:** At least **llvm7** is required for `elf64lppc` emulation in `lld`.

Commands on ppc64le:
$ junixsocket-native/crossclang/bin/prepare-target-sdk
$ junixsocket-native/crossclang/bin/sync-target-sdk \\
  junixsocket-native/crossclang/target-sdks/powerpc64le-suse-linux
$ tar czf ppc64le_env.tgz \\
  junixsocket-native/crossclang/target-sdks/powerpc64le-suse-linux

Commands on x86_64 host:
$ tar xzf ppc64le_env.tgz
$ mv junixsocket-native/crossclang/target-sdks/powerpc64le-suse-linux/ \\
  junixsocket-native/crossclang/target-sdks/powerpc64le-linux-gnu
$ junixsocket-native/crossclang/bin/prepare-target-sdk --all-paths
$ junixsocket-native/crossclang/bin/sync-target-sdk \\
  junixsocket-native/crossclang/target-sdks/x86_64-unknown-linux-gnu
$ mv junixsocket-native/crossclang/target-sdks/x86_64-unknown-linux-gnu/ \\
  junixsocket-native/crossclang/target-sdks/x86_64-pc-linux-gnu/
$ mvn clean install -Dcross=true -Dmaven.javadoc.skip=true

For testing only with Linux amd64 and ppc64le:
https://github.com/sriemer/junixsocket/commits/ppc64le

**This includes PR #64** as it is required for proper compilation.