### PR TITLE
MacOS: minimum supported SDK for Apple Notarization is 10.9

### DIFF
--- a/junixsocket-native/crossclang/bin/clang
+++ b/junixsocket-native/crossclang/bin/clang
@@ -321,7 +321,7 @@ if [ $needLinker -gt 0 ]; then
         ;;
         ld64)
         ldPath=$(which ld64.lld)
-        clangLinkerArgs+=("-Wl,-sdk_version,10.7")
+        clangLinkerArgs+=("-Wl,-sdk_version,10.9")
         #if [ $nostdlib -gt 0 ]; then
         #  clangLinkerArgs+=("-Wl,-undefined,dynamic_lookup")
         #fi


### PR DESCRIPTION
See 
https://developer.apple.com/documentation/xcode/notarizing_macos_software_before_distribution/resolving_common_notarization_issues