### PR TITLE
77 - null check on classloader use in sync to avoid an exception 

### DIFF
--- a/junixsocket-common/src/main/java/org/newsclub/net/unix/NativeLibraryLoader.java
+++ b/junixsocket-common/src/main/java/org/newsclub/net/unix/NativeLibraryLoader.java
@@ -213,7 +213,7 @@ final class NativeLibraryLoader implements Closeable {
   @SuppressWarnings("resource")
   // NOPMD
   public synchronized void loadLibrary() {
-    synchronized (getClass().getClassLoader()) { // NOPMD We want to lock this class' classloader.
+    synchronized (getClass().getClassLoader() != null ? getClass().getClassLoader() : getClass()) { // NOPMD We want to lock this class' classloader.
       if (loaded) {
         // Already loaded
         return;


### PR DESCRIPTION
 null check on classloader use in sync to avoid an exception 

https://github.com/kohlschutter/junixsocket/issues/77