### PR TITLE
Fix file descriptor leak issue

### DIFF
--- a/junixsocket-common/src/main/java/org/newsclub/net/unix/AFUNIXServerSocket.java
+++ b/junixsocket-common/src/main/java/org/newsclub/net/unix/AFUNIXServerSocket.java
@@ -217,7 +217,7 @@ public class AFUNIXServerSocket extends ServerSocket implements FileDescriptorAc
   @Override
   public AFUNIXSocket accept() throws IOException {
     AFUNIXSocket as = newSocketInstance();
-    boolean success = implementation.accept0(as.getAFImpl());
+    boolean success = implementation.accept0(as.impl);
     if (isClosed()) {
       // We may have connected to the socket to unblock it
       throw new SocketException("Socket is closed");

--- a/junixsocket-common/src/main/java/org/newsclub/net/unix/AFUNIXSocket.java
+++ b/junixsocket-common/src/main/java/org/newsclub/net/unix/AFUNIXSocket.java
@@ -38,7 +38,7 @@ public final class AFUNIXSocket extends Socket implements AFUNIXSomeSocket, AFUN
 
   private static Integer capabilities = null;
 
-  private AFUNIXSocketImpl impl;
+  AFUNIXSocketImpl impl;
 
   private final AFUNIXSocketFactory socketFactory;
   private final Closeables closeables = new Closeables();


### PR DESCRIPTION
We discovered a file descriptor leak while using junixsocket 2.4.0. We found that the AFUNIXServerSocket#accept() method will call the AFUNIXSocket#getAFImpl method before calling the accept syscall. AFUNIXSocket#getAFImpl will call the JNI function NativeUnixSocket#createSocket to create a file descriptor. The specific call chain is as follows:

AFUNIXSocket#getAFImpl -> Socket#getSoTimeout -> Socket#getImpl -> Socket#createImpl -> AFUNIXSocketImpl#create -> NativeUnixSocket#createSocket

However, during the execution of AFUNIXSocketImpl#accept0, another fd will be created through the NativeUnixSocket#accept JNI function, and the original fd is not closed.

We fixed it with reference to the implementation of junixsocket 2.3.3 and verified its feasibility.

So we created this Pull Request, hoping to fix this issue.