### PR TITLE
Fix file descriptor leak under high concurrency

### DIFF
--- a/junixsocket-common/src/main/java/org/newsclub/net/unix/AFSelectionKey.java
+++ b/junixsocket-common/src/main/java/org/newsclub/net/unix/AFSelectionKey.java
@@ -66,16 +66,8 @@ final class AFSelectionKey extends SelectionKey {
     return !hasOpInvalid() && !cancelled.get() && chann.isOpen() && sel.isOpen();
   }
 
-  boolean isCancelled() {
-    return cancelled.get();
-  }
-
   boolean hasOpInvalid() {
     return (opsReady & OP_INVALID) != 0;
-  }
-
-  boolean isSelected() {
-    return readyOps() != 0;
   }
 
   @Override
@@ -84,18 +76,6 @@ final class AFSelectionKey extends SelectionKey {
       return;
     }
     sel.prepareRemove(this);
-  }
-
-  void cancelNoRemove() {
-    if (!cancelled.compareAndSet(false, true) || !chann.isOpen()) {
-      return;
-    }
-
-    cancel1();
-  }
-
-  private void cancel1() {
-    // FIXME
   }
 
   @Override


### PR DESCRIPTION
With our PoC at
https://github.com/kevink-sq/jetty-concurrency-issue-poc/tree/575469b3453e7b09d9d60f6460cdab8117b8e773, we noticed that there is unbounded growth of file descriptors when running our simple load test:

```bash
seq 1 15000 | xargs -P1500 -I{} curl --unix-socket ./junix-ingress.sock http://localhost/process
```

Leading to timeouts from curl and timeout exceptions in jetty:

```
java.util.concurrent.TimeoutException: Idle timeout expired: 32422/30000 ms
        at org.eclipse.jetty.io.IdleTimeout.checkIdleTimeout(IdleTimeout.java:170)
        at org.eclipse.jetty.io.IdleTimeout.idleCheck(IdleTimeout.java:112)
        at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539)
        at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
        at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:304)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
        at java.base/java.lang.Thread.run(Thread.java:833)
```

This patch fixes the issue by ensuring that keys with the `OP_INVALID` bit are still tracked in the selected key set and cancelled accordingly

Changes:
* Add invalid keys to `selectedKeysSet` in `setOpsReady` and mark as cancelled, ensuring that the fd is cleaned up timely
* Switch from `cancelNoRemove` to `cancel` now that the registered keys are modified separately in the select implementation
* Prefer `!key.isValid()` over `key.hasOpInvalid()` since the former is a superset of the latter
* In `implCloseSelector`, cancel the keys before clearing `keysRegistered` since `keys()` is backed by `keysRegistered`
* Store cancelled keys in a deque instead of a hash set, which should be a little more efficient
* Remove dead code