### PR TITLE
Rework AFSelector to normalize and simplify its locking

### DIFF
--- a/junixsocket-common/src/main/java/org/newsclub/net/unix/AFSelectionKey.java
+++ b/junixsocket-common/src/main/java/org/newsclub/net/unix/AFSelectionKey.java
@@ -66,16 +66,8 @@ final class AFSelectionKey extends SelectionKey {
     return !hasOpInvalid() && !cancelled.get() && chann.isOpen() && sel.isOpen();
   }
 
-  boolean isCancelled() {
-    return cancelled.get();
-  }
-
   boolean hasOpInvalid() {
     return (opsReady & OP_INVALID) != 0;
-  }
-
-  boolean isSelected() {
-    return readyOps() != 0;
   }
 
   @Override
@@ -84,18 +76,6 @@ final class AFSelectionKey extends SelectionKey {
       return;
     }
     sel.prepareRemove(this);
-  }
-
-  void cancelNoRemove() {
-    if (!cancelled.compareAndSet(false, true) || !chann.isOpen()) {
-      return;
-    }
-
-    cancel1();
-  }
-
-  private void cancel1() {
-    // FIXME
   }
 
   @Override

--- a/junixsocket-common/src/main/java/org/newsclub/net/unix/AFSelectionKey.java
+++ b/junixsocket-common/src/main/java/org/newsclub/net/unix/AFSelectionKey.java
@@ -75,7 +75,7 @@ final class AFSelectionKey extends SelectionKey {
     if (!cancelled.compareAndSet(false, true) || !chann.isOpen()) {
       return;
     }
-    sel.prepareRemove(this);
+    sel.cancel(this);
   }
 
   @Override

--- a/junixsocket-common/src/main/java/org/newsclub/net/unix/AFSelector.java
+++ b/junixsocket-common/src/main/java/org/newsclub/net/unix/AFSelector.java
@@ -116,7 +116,7 @@ final class AFSelector extends AbstractSelector {
         throw new ClosedSelectorException();
       }
       pfd = pollFd = initPollFd(pollFd);
-      performRemove();
+      processDeregisterQueue();
       selectedKeysSet.clear();
     }
     int num;
@@ -301,13 +301,13 @@ final class AFSelector extends AbstractSelector {
     return this;
   }
 
-  void prepareRemove(AFSelectionKey key) {
+  public void cancel(AFSelectionKey key) {
     synchronized (cancelledKeys) {
       cancelledKeys.addLast(key);
     }
   }
 
-  void performRemove() {
+  void processDeregisterQueue() {
     synchronized (cancelledKeys) {
       SelectionKey key;
       while ((key = cancelledKeys.pollFirst()) != null) {


### PR DESCRIPTION
Note that this PR is split into three commits; the first two commits are mainly renames to make the implementation more consistent with the Java standard library's implementations. For reviewing, strongly recommend ignoring whitespace changes.

Changes:
* Place bulk of `select0` operations under `this` and
  `publicSelectedKeys` locks to reduce locking/unlocking thrash given
  frequency of locking operations
* Lock `publicSelectedKeys` instead of `selectedKeys` since that is what
  clients of AFSelector are locking on
* Eschew uses of synchronized methods in favor of locking `this` via
  synchronized blocks
* Use assertions to check lock invariants