### PR TITLE
Lock all read/writes of selected keys via the public key set

### DIFF
--- a/junixsocket-common/src/main/java/org/newsclub/net/unix/AFSelectionKey.java
+++ b/junixsocket-common/src/main/java/org/newsclub/net/unix/AFSelectionKey.java
@@ -66,16 +66,8 @@ final class AFSelectionKey extends SelectionKey {
     return !hasOpInvalid() && !cancelled.get() && chann.isOpen() && sel.isOpen();
   }
 
-  boolean isCancelled() {
-    return cancelled.get();
-  }
-
   boolean hasOpInvalid() {
     return (opsReady & OP_INVALID) != 0;
-  }
-
-  boolean isSelected() {
-    return readyOps() != 0;
   }
 
   @Override
@@ -84,18 +76,6 @@ final class AFSelectionKey extends SelectionKey {
       return;
     }
     sel.prepareRemove(this);
-  }
-
-  void cancelNoRemove() {
-    if (!cancelled.compareAndSet(false, true) || !chann.isOpen()) {
-      return;
-    }
-
-    cancel1();
-  }
-
-  private void cancel1() {
-    // FIXME
   }
 
   @Override


### PR DESCRIPTION
This ensures that the selector and its clients use the same lock to synchronize access to the selected keys

Changes:
* Always lock on `selectedKeysPublic` to be consistent with clients
* Synchronize on `selectedKeysPublic` when adding or clearing selected keys
* Reorder the calls to `consumeAllBytesAfterPoll` and `selectedKeysPublic.clear()` after polling in order to push down the lock on `selectedKeysPublic`. This should be safe since neither the channel closing loop nor `consumeAllBytesAfterPoll` operates on the selected key set
* Remove redudnant use of `synchronized` on methods that are always called under a lock on `this`. Use assertions to document what locks are required for the given method instead